### PR TITLE
super-linterのorganization名修正・アップデート

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -48,7 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v5.0.0
+        uses: super-linter/super-linter/slim@v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -48,7 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter/slim@v5.0.0
+        uses: super-linter/super-linter/slim@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.16.2
+    rev: v8.18.0
     hooks:
       - id: gitleaks

--- a/scripts/action/update.sh
+++ b/scripts/action/update.sh
@@ -11,4 +11,4 @@ while IFS= read -r -d '' f; do
 done < <(find .github/workflows -type f -print0)
 
 curl "https://raw.githubusercontent.com/super-linter/super-linter/${version}/TEMPLATES/.gitleaks.toml" >.gitleaks.toml
-yq -i ".repos[].rev = \"$(docker run --entrypoint gitleaks "super-linter/super-linter:slim-${version}" version | sed -e 's/\r//g')\"" .pre-commit-config.yaml
+yq -i ".repos[].rev = \"$(docker run --entrypoint gitleaks "ghcr.io/super-linter/super-linter:slim-${version}" version | sed -e 's/\r//g')\"" .pre-commit-config.yaml

--- a/scripts/action/update.sh
+++ b/scripts/action/update.sh
@@ -3,12 +3,12 @@
 version=""
 
 while IFS= read -r -d '' f; do
-  v="$(yq '.jobs.*.steps[].uses | select(. == "github/super-linter*")' "${f}" | sed -e 's/.*@//g')"
+  v="$(yq '.jobs.*.steps[].uses | select(. == "super-linter/super-linter*")' "${f}" | sed -e 's/.*@//g')"
   if [ -n "${v}" ]; then
     version="${v}"
     break
   fi
 done < <(find .github/workflows -type f -print0)
 
-curl "https://raw.githubusercontent.com/github/super-linter/${version}/TEMPLATES/.gitleaks.toml" >.gitleaks.toml
-yq -i ".repos[].rev = \"$(docker run --entrypoint gitleaks "github/super-linter:slim-${version}" version | sed -e 's/\r//g')\"" .pre-commit-config.yaml
+curl "https://raw.githubusercontent.com/super-linter/super-linter/${version}/TEMPLATES/.gitleaks.toml" >.gitleaks.toml
+yq -i ".repos[].rev = \"$(docker run --entrypoint gitleaks "super-linter/super-linter:slim-${version}" version | sed -e 's/\r//g')\"" .pre-commit-config.yaml


### PR DESCRIPTION
https://github.com/super-linter/super-linter
>NOTICE: If your use of the super-linter action failed around April 26th, 2023, we changed the organization name from github to super-linter so you will need to update your references to this action from github/super-linter to super-linter/super-linter.

super-linterのorganization名を修正します。
また、 `ghcr.io/super-linter/super-linter` ( https://github.com/super-linter/super-linter/pkgs/container/super-linter/versions?filters%5Bversion_type%5D=tagged ) にはsuper-linterの古いバージョンのDockerイメージがないため、最新へのアップデートも行います。