### PR TITLE
super-linterのWarning修正

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,71 @@
+---
+# https://github.com/super-linter/super-linter/blob/d0b304a6a58b560749c679157953fec8ba7206df/TEMPLATES/.eslintrc.yml
+env:
+  browser: true
+  es6: true
+  jest: true
+  node: true
+extends:
+  - "eslint:recommended"
+ignorePatterns:
+  - "!.*"
+  - "**/node_modules/.*"
+plugins:
+  - n
+  - prettier
+overrides:
+  # JSON files
+  - files:
+      - "*.json"
+    extends:
+      - plugin:jsonc/recommended-with-json
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSON
+  # JSONC files
+  - files:
+      - "*.jsonc"
+    extends:
+      - plugin:jsonc/recommended-with-jsonc
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSONC
+  # JSON5 files
+  - files:
+      - "*.json5"
+    extends:
+      - plugin:jsonc/recommended-with-json5
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSON5
+  # Javascript files
+  - files:
+      - "**/*.js"
+      - "**/*.mjs"
+      - "**/*.cjs"
+      - "**/*.jsx"
+    #extends:
+    #  - "plugin:react/recommended"
+    parserOptions:
+      sourceType: module
+      ecmaVersion: latest
+      ecmaFeatures:
+        jsx: true
+        modules: true
+  # TypeScript files
+  - files:
+      - "**/*.ts"
+      - "**/*.cts"
+      - "**/*.mts"
+      - "**/*.tsx"
+    extends:
+      - "plugin:@typescript-eslint/recommended"
+      - plugin:n/recommended
+      #- plugin:react/recommended
+      - prettier
+    parser: "@typescript-eslint/parser"
+    plugins:
+      - "@typescript-eslint"
+    parserOptions:
+      ecmaVersion: latest
+      sourceType: module

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -57,6 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
           LINTER_RULES_PATH: .
+          VALIDATE_TYPESCRIPT_STANDARD: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,8 @@
+// https://github.com/super-linter/super-linter/blob/5d6e3fcecc2b2906eedc2d15495fd6027bf51a9e/commitlint.config.js
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  helpUrl: "https://www.conventionalcommits.org/",
+  // We need this until https://github.com/dependabot/dependabot-core/issues/2445
+  // is resolved.
+  ignores: [(msg: string) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
+};


### PR DESCRIPTION
以下のWarningを修正します。

https://github.com/dev-hato/actions-update-gitleaks/actions/runs/13622168938/job/38073375260#step:6:147

```
  2025-03-03 02:33:12 [WARN]   Git commit message validation with commitlint is enabled, but no commitlint configuration file is available. Disabling commitlint. To suppress this message, either disable Git commit validation by setting VALIDATE_GIT_COMMITLINT to false in your Super-linter configuration, or provide a commitlint configuration file.
```